### PR TITLE
Sortable tree proof-of-concept

### DIFF
--- a/tests/dummy/app/components/leaf-item.js
+++ b/tests/dummy/app/components/leaf-item.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+import layout from '../templates/components/leaf-item';
+
+export default Ember.Component.extend({
+  leaf: null,
+  sortingScope: 'leaf',
+
+  layout: layout,
+  classNames: ['leaf'],
+
+  actions: {
+    sortEndAction: function() {
+      console.log('Sort Ended', this.get('leaf.children'));
+    }
+  }
+});

--- a/tests/dummy/app/models/leaf.js
+++ b/tests/dummy/app/models/leaf.js
@@ -1,0 +1,9 @@
+import Model from 'ember-data/model';
+import {hasMany, belongsTo} from 'ember-data/relationships';
+
+var Book = Model.extend({
+  parent: belongsTo('leaf', {inverse: 'children'}),
+  children: hasMany('leaf', {inverse: 'parent'})
+});
+
+export default Book;

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
   this.resource("sortdata");
   this.resource("handle");
   this.resource("nesteddata");
+  this.resource("treedata");
 });
 
 export default Router;

--- a/tests/dummy/app/routes/treedata.js
+++ b/tests/dummy/app/routes/treedata.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  createdStore: false,
+  model: function() {
+    if (!this.get('createdStore')) {
+      return this
+        .store
+        .createRecord('leaf', {
+          id: '1',
+          children: [
+            this.store.createRecord('leaf', {
+              id: '2',
+              children: [
+                this.store.createRecord('leaf', {id: '3'}),
+                this.store.createRecord('leaf', {id: '4'}),
+                this.store.createRecord('leaf', {id: '5'})
+              ]
+            }),
+            this.store.createRecord('leaf', {
+              id: '6',
+              children: [
+                this.store.createRecord('leaf', {id: '7'}),
+                this.store.createRecord('leaf', {id: '8'})
+              ]
+            }),
+            this.store.createRecord('leaf', {
+              id: '9',
+              children: [
+                this.store.createRecord('leaf', {id: '10'}),
+                this.store.createRecord('leaf', {id: '11'}),
+                this.store.createRecord('leaf', {id: '12'})
+              ]
+            })
+          ]
+        });
+    }
+  }
+});

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -7,3 +7,4 @@
 @import "draggable-object-target";
 @import "sortable-objects";
 @import "object-bin";
+@import "leaf";

--- a/tests/dummy/app/styles/leaf.sass
+++ b/tests/dummy/app/styles/leaf.sass
@@ -1,0 +1,11 @@
+.leaf-wrapper
+  background-color: transparent !important
+
+.leaf
+  background-color: rgba(deepskyblue, 0.1)
+
+.leaf-children
+  padding: 1em 0
+
+  > .leaf-wrapper
+    margin: 1em 0

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,11 +2,12 @@
 <h2><a href="https://github.com/mharris717/ember-drag-drop">https://github.com/mharris717/ember-drag-drop</a></h2>
 
 <ul class="nav">
-  <li>{{#link-to 'simple'}}A simple Drag and Drop Example{{/link-to}}</li>
-  <li>{{#link-to 'sort'}}A Simple Sorting Example with POJO{{/link-to}}</li>
-  <li>{{#link-to 'sortdata'}}A Simple Sorting  with Ember Data{{/link-to}}</li>
-  <li>{{#link-to 'handle'}}Drag with a handle{{/link-to}}</li>
-  <li>{{#link-to 'nesteddata'}}Nested Sorting with Ember Data{{/link-to}}</li>
+  <li>{{link-to 'A simple Drag and Drop Example'     'simple'}}</li>
+  <li>{{link-to 'A Simple Sorting Example with POJO' 'sort'}}</li>
+  <li>{{link-to 'A Simple Sorting  with Ember Data'  'sortdata'}}</li>
+  <li>{{link-to 'Drag with a handle'                 'handle'}}</li>
+  <li>{{link-to 'Nested Sorting with Ember Data'     'nesteddata'}}</li>
+  <li>{{link-to 'Tree Sorting with Ember Data'       'treedata'}}</li>
 </ul>
 
 {{outlet}}

--- a/tests/dummy/app/templates/components/leaf-item.hbs
+++ b/tests/dummy/app/templates/components/leaf-item.hbs
@@ -1,0 +1,24 @@
+<p>Leaf {{leaf.id}}</p>
+
+{{#sortable-objects
+  sortableObjectList=leaf.children
+  sortEndAction='sortEndAction'
+  class='leaf-children'
+  sortingScope=sortingScope
+}}
+
+  {{#each leaf.children as |child|}}
+    {{#draggable-object
+      content=child
+      class='leaf-wrapper draggable-object'
+      sortingScope=sortingScope
+      isSortable=true
+    }}
+      {{leaf-item
+        leaf=child
+        sortingScope=sortingScope
+      }}
+    {{/draggable-object}}
+  {{/each}}
+
+{{/sortable-objects}}

--- a/tests/dummy/app/templates/nesteddata.hbs
+++ b/tests/dummy/app/templates/nesteddata.hbs
@@ -72,6 +72,8 @@
     <a href="https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/templates/nesteddata.hbs" target="_blank">https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/templates/nesteddata.hbs</a>
     <h5>Controller:</h5>
     <a href="https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/controllers/nesteddata.js" target="_blank">https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/controllers/nesteddata.js</a>
+    <h5>Route:</h5>
+    <a href="https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/routes/nesteddata.js" target="_blank">https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/routes/nesteddata.js</a>
   </div>
 </div>
 

--- a/tests/dummy/app/templates/sortdata.hbs
+++ b/tests/dummy/app/templates/sortdata.hbs
@@ -30,6 +30,8 @@
    <a href="https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/templates/sort.hbs" target="_blank">https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/templates/sort.hbs</a>
     <h5>Controller:</h5>
     <a href="https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/controllers/sort.js" target="_blank">https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/controllers/sort.js</a>
+    <h5>Route:</h5>
+    <a href="https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/routes/sort.js" target="_blank">https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/routes/sort.js</a>
   </div>
 </div>
 

--- a/tests/dummy/app/templates/treedata.hbs
+++ b/tests/dummy/app/templates/treedata.hbs
@@ -1,0 +1,27 @@
+<h3>A tree sorting example (WIP)</h3>
+<p>Drag to change the hierarchy of leaves</p>
+
+
+<div class="grid">
+  <div class="block">
+    <h4>Demo:</h4>
+
+    {{leaf-item
+      leaf=model
+      sortingScope='leaf'
+    }}
+    {{/sortable-objects}}
+
+  </div>
+
+
+  <div class="block auto">
+    <h4>Resources:</h4>
+    <h5>Template:</h5>
+    <a href="https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/templates/treedata.hbs" target="_blank">https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/templates/treedata.hbs</a>
+    <h5>Controller:</h5>
+    <a href="https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/controllers/treedata.js" target="_blank">https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/controllers/treedata.js</a>
+    <h5>Route:</h5>
+    <a href="https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/routes/treedata.js" target="_blank">https://github.com/mharris717/ember-drag-drop/blob/master/tests/dummy/app/routes/treedata.js</a>
+  </div>
+</div>


### PR DESCRIPTION
As discussed with @dgavey, I implemented a prototype for tree sorting based on @Bushjumper's effort.

This PR contains no modifications to the addon, only a new dummy app page with a sortable tree experiment.

Here's a prototype I built long ago with jQuery UI Sortable: http://hivemindunit.github.io/hivemind-frontend-prototype/settings/domains/categories2/

I'm now trying to do an identical tree with Ember, and it's a tough nut to crack. :(

@Bushjumper's PR seems to be capable of it, but sorting experience is very fuzzy. Items don't want to go where I try to put them.

In the jQuery UI Sortable prototype, I had spent a lot of time figuring margins, paddings, min heights and collapsing elements in order to produce satisfactory user experience.

Maybe this experiment also needs only some CSS adjustments to work right. But maybe it needs more than that. @Bushjumper, @dgavey, @linearza: can you guys please have a look and see why sorting experience is so unstable?

Within the nested context, an item has many sortable container parents. And when you drag an item over one of them, it might fail to properly determine which of the nested containers is the target. In my jQuery prototype I used `event.target` to pick the innermost container.

PS Here's the source of the jQuery prototype: https://gist.github.com/lolmaus/ae947df1e3623c5b0ed06741f1919227
